### PR TITLE
Fixed 2 issues of type: PYTHON_E241 throughout 2 files in repo.

### DIFF
--- a/shell/plugins/commands.py
+++ b/shell/plugins/commands.py
@@ -63,7 +63,7 @@ class CommandsPlugin(BasePlugin):
 
         cmds_text += self.print_pairs('Output Information', body={
             'Created On  ': cmd.output.created_on,
-            'Output      ':  f'{ self.t.bold_white("<< output below >>") }\n{ js_beautify(cmd.output.text) }',
+            'Output      ': f'{ self.t.bold_white("<< output below >>") }\n{ js_beautify(cmd.output.text) }',
         }, just_return=True)
 
         self.ppaged(cmds_text)

--- a/shell/plugins/dump.py
+++ b/shell/plugins/dump.py
@@ -69,7 +69,7 @@ class DumpPlugin(BasePlugin):
         if cmd.output:
             cmds_text += '\n\n' + self.print_pairs('Output Information', body={
                 'Created On  ': cmd.output.created_on,
-                'Output      ':  f'"<< output below >>" \n{ js_beautify(cmd.output.text, colors=False) }',
+                'Output      ': f'"<< output below >>" \n{ js_beautify(cmd.output.text, colors=False) }',
             }, just_return=True, colors=False)
 
         with open(file_name, 'w') as f:


### PR DESCRIPTION
PYTHON_E241: 'Fix extraneous whitespace around keywords.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.