### PR TITLE
Fixed 6 issues of type: PYTHON_E402 throughout 4 files in repo.

### DIFF
--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,3 +1,6 @@
+from web.api import api as api_bp
+from web.content import content as content_bp
+from web.main import main as main_bp
 from flask import Flask
 from flask_cors import CORS
 
@@ -12,13 +15,10 @@ CORS(app)
 
 db.init_app(app)
 
-from web.api import api as api_bp
 app.register_blueprint(api_bp)
 
-from web.content import content as content_bp
 app.register_blueprint(content_bp)
 
-from web.main import main as main_bp
 app.register_blueprint(main_bp)
 
 

--- a/web/api/__init__.py
+++ b/web/api/__init__.py
@@ -1,4 +1,4 @@
+from web.api import routes
 from flask import Blueprint
 
 api = Blueprint('api', __name__, url_prefix='/api')
-from web.api import routes

--- a/web/content/__init__.py
+++ b/web/content/__init__.py
@@ -1,4 +1,4 @@
+from web.content import routes
 from flask import Blueprint
 
 content = Blueprint('content', __name__, url_prefix='/content')
-from web.content import routes

--- a/web/main/__init__.py
+++ b/web/main/__init__.py
@@ -1,4 +1,4 @@
+from web.main import routes
 from flask import Blueprint
 
 main = Blueprint('main', __name__, url_prefix='/')
-from web.main import routes


### PR DESCRIPTION
PYTHON_E402: 'module level import not at top of file'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.